### PR TITLE
Fix textStyle does not work

### DIFF
--- a/downloadable-calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/TypefaceUtils.java
+++ b/downloadable-calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/TypefaceUtils.java
@@ -48,7 +48,7 @@ public final class TypefaceUtils {
                     if (view == null) {
                         return;
                     }
-                    view.setTypeface(typeface);
+                    view.setTypeface(typeface, view.getTypeface().getStyle());
                     if (deferred) {
                         view.setText(CalligraphyUtils.applyTypefaceSpan(view.getText(), typeface), TextView.BufferType.SPANNABLE);
                         view.addTextChangedListener(new TextWatcher() {


### PR DESCRIPTION
Since a new `setTypeface()` method was added to AppCompatTextView in AndroidX, I added style to argument. close #5 